### PR TITLE
Add example for voice upload and 3D text display

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
-# bell
+# Bell Example Project
+
+This repository demonstrates a simple pipeline for recording audio on a mobile device and uploading it to a PHP server. A Python script downloads the audio, transcribes it with the Vosk speech recognition library, and saves the results. Finally, a small Three.js page displays the transcribed text dropping from the top of the screen.
+
+## Components
+
+- `client/mobile_record.html` – records audio in the browser and uploads it to `server/upload.php`.
+- `server/upload.php` – saves uploaded audio files under `server/uploads/`.
+- `server/list.php` – lists available uploaded files as JSON.
+- `client/pull_transcribe.py` – downloads audio files, converts them with `ffmpeg`, and transcribes them using Vosk.
+- `display.html` – loads `transcripts.json` and shows each line of text falling in 3D using Three.js.
+
+To use the Python script you must install `vosk`, `requests`, and `ffmpeg`, and download a Vosk model into a `model/` directory.

--- a/client/mobile_record.html
+++ b/client/mobile_record.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Record Audio</title>
+</head>
+<body>
+  <button id="record">Record</button>
+  <button id="stop" disabled>Stop</button>
+  <script>
+    let mediaRecorder;
+    let chunks = [];
+    document.getElementById('record').onclick = async () => {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      mediaRecorder = new MediaRecorder(stream);
+      mediaRecorder.ondataavailable = e => chunks.push(e.data);
+      mediaRecorder.onstop = handleStop;
+      mediaRecorder.start();
+      chunks = [];
+      document.getElementById('record').disabled = true;
+      document.getElementById('stop').disabled = false;
+    };
+    document.getElementById('stop').onclick = () => {
+      mediaRecorder.stop();
+      document.getElementById('record').disabled = false;
+      document.getElementById('stop').disabled = true;
+    };
+    function upload(blob){
+      const formData = new FormData();
+      formData.append('audio', blob, 'recording.webm');
+      fetch('../server/upload.php', { method: 'POST', body: formData });
+    }
+    function handleStop(){
+      const blob = new Blob(chunks, { type: 'audio/webm' });
+      upload(blob);
+    }
+  </script>
+</body>
+</html>

--- a/client/pull_transcribe.py
+++ b/client/pull_transcribe.py
@@ -1,0 +1,64 @@
+import os
+import json
+import requests
+import subprocess
+import wave
+from vosk import Model, KaldiRecognizer
+
+SERVER = "http://yourserver.com/server"  # replace with real server URL
+AUDIO_DIR = "downloaded_audio"
+TRANS_FILE = "transcripts.json"
+MODEL_PATH = "model"  # path to Vosk model
+
+
+def list_files():
+    r = requests.get(f"{SERVER}/list.php")
+    r.raise_for_status()
+    return r.json()
+
+
+def download_file(fname):
+    os.makedirs(AUDIO_DIR, exist_ok=True)
+    local = os.path.join(AUDIO_DIR, os.path.basename(fname))
+    if not os.path.exists(local):
+        url = f"{SERVER}/{fname}"
+        with requests.get(url, stream=True) as r:
+            r.raise_for_status()
+            with open(local, 'wb') as f:
+                for chunk in r.iter_content(chunk_size=8192):
+                    f.write(chunk)
+    return local
+
+
+def to_wav(path):
+    wav = os.path.splitext(path)[0] + '.wav'
+    if not os.path.exists(wav):
+        subprocess.run(["ffmpeg", "-y", "-i", path, wav], check=True)
+    return wav
+
+
+def transcribe(wav_path, recognizer):
+    with wave.open(wav_path, 'rb') as wf:
+        data = wf.readframes(wf.getnframes())
+    if recognizer.AcceptWaveform(data):
+        res = json.loads(recognizer.Result())
+        return res.get('text', '')
+    return ''
+
+
+def main():
+    files = list_files()
+    model = Model(MODEL_PATH)
+    rec = KaldiRecognizer(model, 16000)
+    transcripts = []
+    for f in files:
+        local = download_file(f)
+        wav = to_wav(local)
+        text = transcribe(wav, rec)
+        transcripts.append({'file': f, 'text': text})
+    with open(TRANS_FILE, 'w', encoding='utf-8') as out:
+        json.dump(transcripts, out, ensure_ascii=False, indent=2)
+
+
+if __name__ == '__main__':
+    main()

--- a/client/pull_transcribe.py
+++ b/client/pull_transcribe.py
@@ -5,7 +5,7 @@ import subprocess
 import wave
 from vosk import Model, KaldiRecognizer
 
-SERVER = "http://yourserver.com/server"  # replace with real server URL
+SERVER = "https://ida.tw/interative/bell/server"  # replace with real server URL
 AUDIO_DIR = "downloaded_audio"
 TRANS_FILE = "transcripts.json"
 MODEL_PATH = "model"  # path to Vosk model

--- a/display.html
+++ b/display.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>3D Text Drop</title>
+<style>body{margin:0;overflow:hidden;}</style>
+</head>
+<body>
+<script src="https://cdn.jsdelivr.net/npm/three@0.154/build/three.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/three@0.154/examples/jsm/loaders/FontLoader.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/three@0.154/examples/jsm/geometries/TextGeometry.js"></script>
+<script>
+const scene = new THREE.Scene();
+const camera = new THREE.PerspectiveCamera(75, window.innerWidth/window.innerHeight, 0.1, 1000);
+const renderer = new THREE.WebGLRenderer();
+renderer.setSize(window.innerWidth, window.innerHeight);
+document.body.appendChild(renderer.domElement);
+
+function drop(mesh){
+  function animate(){
+    mesh.position.y -= 0.05;
+    if(mesh.position.y>-10) requestAnimationFrame(animate);
+  }
+  animate();
+}
+
+const loader = new THREE.FontLoader();
+loader.load('https://threejs.org/examples/fonts/helvetiker_regular.typeface.json', font => {
+  fetch('transcripts.json').then(r=>r.json()).then(data=>{
+    let y = 5;
+    data.forEach(item=>{
+      const geo = new THREE.TextGeometry(item.text || '',{font,size:0.5,height:0.1});
+      const mat = new THREE.MeshBasicMaterial({color:0xff6600});
+      const mesh = new THREE.Mesh(geo, mat);
+      mesh.position.set(-2,y,0);
+      scene.add(mesh);
+      drop(mesh);
+      y += 1.5;
+    });
+  });
+});
+
+camera.position.z = 5;
+(function animate(){
+  requestAnimationFrame(animate);
+  renderer.render(scene, camera);
+})();
+</script>
+</body>
+</html>

--- a/server/list.php
+++ b/server/list.php
@@ -1,0 +1,12 @@
+<?php
+$dir = __DIR__ . '/uploads/';
+$files = [];
+if (is_dir($dir)) {
+    foreach (glob($dir . '*') as $file) {
+        $files[] = 'uploads/' . basename($file);
+    }
+}
+sort($files);
+header('Content-Type: application/json');
+echo json_encode($files);
+?>

--- a/server/upload.php
+++ b/server/upload.php
@@ -1,0 +1,19 @@
+<?php
+$target_dir = __DIR__ . '/uploads/';
+if (!file_exists($target_dir)) {
+    mkdir($target_dir, 0777, true);
+}
+if (isset($_FILES['audio'])) {
+    $fname = time() . '_' . basename($_FILES['audio']['name']);
+    $target_file = $target_dir . $fname;
+    if (move_uploaded_file($_FILES['audio']['tmp_name'], $target_file)) {
+        echo json_encode(['status' => 'ok', 'file' => 'uploads/' . $fname]);
+    } else {
+        http_response_code(500);
+        echo json_encode(['status' => 'error']);
+    }
+} else {
+    http_response_code(400);
+    echo json_encode(['status' => 'no file']);
+}
+?>


### PR DESCRIPTION
## Summary
- build a basic demo to record audio in browser and upload to PHP server
- add PHP scripts to save uploads and list them
- add Python tool to download and transcribe audio via Vosk
- include a Three.js page that drops text in 3D
- update README with instructions

## Testing
- `python3 -m py_compile client/pull_transcribe.py`


------
https://chatgpt.com/codex/tasks/task_e_6840580b1f70832192755f6d81628785